### PR TITLE
Remove CLEANUP log message

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -157,7 +157,6 @@ Agent.prototype._init = function initSock(dtlsOpts, newCallback) {
 }
 
 Agent.prototype.finish = function finish(req) {
-  console.log("CLEANUP")
   for (var k in this._msgIdToReq)
     this._msgIdToReq[k].sender.reset()
     delete this._msgIdToReq[k]


### PR DESCRIPTION
I'm using the tradfri pimatic plugin which again uses tradfri-coapdtls. It's pretty annoying that the log file is cluttered with "CLEANUP" messages, so I would like to remove this line. 